### PR TITLE
feat: prepend a node-gyp wrapper, closes #4

### DIFF
--- a/bin/node-gyp
+++ b/bin/node-gyp
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# this is a tiny wrapper that will be prepended to the front of the PATH if
+# the npm_config_node_gyp environment variable is set in order to be sure that
+# node-gyp is run from its configured location
+node "$npm_config_node_gyp" "$@"
+

--- a/bin/node-gyp.cmd
+++ b/bin/node-gyp.cmd
@@ -1,0 +1,2 @@
+@node "%npm_config_node_gyp%" %*
+

--- a/lib/path.js
+++ b/lib/path.js
@@ -23,6 +23,13 @@ const getBinPaths = ({ start, top = '/' }) => {
   return binPaths
 }
 
+// this function returns the path to our bin directory that contains the shims
+// for node-gyp if the npm_config_node_gyp environment variable is set, if not
+// we don't since without that value our node-gyp wrapper will fail anyway
+const getGypPath = ({ env }) => env.npm_config_node_gyp
+  ? [path.resolve(__dirname, '../bin')]
+  : []
+
 // take any PATH related environment variables and normalize them into an array
 // we do this because in Windows it's typically Path, but that's not guaranteed
 // and it can also come from more than one environment variable. we merge them
@@ -41,6 +48,7 @@ const normalizePath = ({ env }) => {
 // values. we intentionally do not modify the original env object
 const setPath = ({ env, start, top }) => {
   const fullPath = [
+    ...getGypPath({ env }),
     ...getBinPaths({ start, top }),
     ...normalizePath({ env }),
   ].join(path.delimiter)
@@ -58,6 +66,7 @@ const setPath = ({ env, start, top }) => {
 
 module.exports = {
   getBinPaths,
+  getGypPath,
   normalizePath,
   setPath,
 }


### PR DESCRIPTION
when the npm_config_node_gyp environment variable is set, we put
our own bin directory to the front of the PATH so that our wrapper
is used and the correct node-gyp is run. if it is not set, we skip
adding ourselves to the PATH because our shim won't work anyway.